### PR TITLE
remove depricated modules

### DIFF
--- a/MultiTrans.py
+++ b/MultiTrans.py
@@ -4,7 +4,6 @@
 from __future__ import print_function
 import sys
 import re
-import commands
 import os
 import time
 


### PR DESCRIPTION
The 'commands' module is depricated since python 2.6. There is no calls to it from the code. But if you really need it do another workaround 'import subprocess as commands'